### PR TITLE
Us 10 admin shelters index

### DIFF
--- a/app/controllers/admin/shelters_controller.rb
+++ b/app/controllers/admin/shelters_controller.rb
@@ -1,0 +1,5 @@
+class Admin::SheltersController < ApplicationController 
+  def index 
+    @shelters = Shelter.all
+  end
+end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -16,6 +16,10 @@ class Shelter < ApplicationRecord
       .order("pets_count DESC")
   end
 
+  def self.reverse_alpha 
+    find_by_sql("SELECT shelters.* FROM shelters ORDER BY shelters.name DESC")
+  end
+
   def pet_count
     pets.count
   end

--- a/app/views/admin/shelters/index.html.erb
+++ b/app/views/admin/shelters/index.html.erb
@@ -1,0 +1,7 @@
+<h1>Admin Shelters</h1>
+<% @shelters.reverse_alpha.each do |shelter| %>
+  <h3><%= shelter.name %></h3>
+   <p>City: <%= shelter.city %></p>
+   <p>Foster Program: <%= shelter.foster_program %></p>
+   <p>Rank: <%= shelter.rank %></p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 Rails.application.routes.draw do
   get "/", to: "application#welcome"
 
+  get "/admin/shelters", to: "admin/shelters#index"
+
   get "/shelters", to: "shelters#index"
   get "/shelters/new", to: "shelters#new"
   get "/shelters/:id", to: "shelters#show"

--- a/spec/features/admin/shelters/index_spec.rb
+++ b/spec/features/admin/shelters/index_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper" 
+
+RSpec.describe "Admin Shelters Index page" do 
+  before(:each) do 
+    @shelter_1 = Shelter.create(name: "Aurora shelter", city: "Aurora, CO", foster_program: false, rank: 9)
+    @shelter_2 = Shelter.create(name: "RGV animal shelter", city: "Harlingen, TX", foster_program: false, rank: 5)
+    @shelter_3 = Shelter.create(name: "Fancy pets of Colorado", city: "Denver, CO", foster_program: true, rank: 10)
+  end
+
+  it "displays all Shelters in the system listed in reverse alphabetical order" do 
+    visit "/admin/shelters"
+
+    expect(page).to have_content("Admin Shelters")
+    expect(page).to have_content("Aurora shelter")
+    expect(page).to have_content("City: Aurora, CO")
+    expect(page).to have_content("Foster Program: false")
+    expect(page).to have_content("Rank: 9")
+    
+    expect(page).to have_content("RGV animal shelter")
+    expect(page).to have_content("City: Harlingen, TX")
+    expect(page).to have_content("Foster Program: false")
+    expect(page).to have_content("Rank: 5")
+    
+    expect(page).to have_content("Fancy pets of Colorado")
+    expect(page).to have_content("City: Denver, CO")
+    expect(page).to have_content("Foster Program: false")
+    expect(page).to have_content("Rank: 10")
+
+    expect("RGV animal shelter").to appear_before("Fancy pets of Colorado")
+    expect("Fancy pets of Colorado").to appear_before("Aurora shelter")
+    
+    save_and_open_page
+  end
+end 

--- a/spec/models/shelter_spec.rb
+++ b/spec/models/shelter_spec.rb
@@ -41,6 +41,12 @@ RSpec.describe Shelter, type: :model do
         expect(Shelter.order_by_number_of_pets).to eq([@shelter_1, @shelter_3, @shelter_2])
       end
     end
+
+    describe "#reverse_alpha" do 
+      it "displays shelters in reverse alphabetical order using shelter name" do 
+        expect(Shelter.reverse_alpha).to eq([@shelter_2, @shelter_3, @shelter_1])
+      end
+    end
   end
 
   describe "instance methods" do


### PR DESCRIPTION
US-10 finished - create new Admin Shelters Index page listing all shelters in the system - along with each of their respective attributes and values - in reverse alphabetical order.  The reqs also mandated only raw SQL could be used for sorting method, implementing Active Record's #find_by_sql method.  Feature tested both content and content order - all tests passing. New shelter model test confirming correct order of shelters returned when #reverse_alpha was called on Shelter model.